### PR TITLE
Add the option for word separator of Resource id

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Usage: simple-api-client-generator [options] <JSON Schema>
 Options:
   -n, --name    API Client class name  [string] [default: "APIClient"]
   -o, --output  output file path  [string]
+  -s, --sep     word separator in URIs  [string] [default: "-"]
   --help        Show help  [boolean]
   --version     Show version number  [boolean]
 
@@ -42,7 +43,7 @@ Output Example is [here](./example/APIClient.js) from [Sample JSON Hyper Schema]
 
 ## Restriction
 
-### Depenencies 
+### Depenencies
 
 Generated Client depends on following modules.
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -30,6 +30,12 @@ const argv = yargs
     'default': 'power-assert',
     type: 'string'
   })
+  .option('s', {
+    alias: 'sep',
+    description: 'word separator in URIs',
+    'default': '-',
+    type: 'string'
+  })
   .help('help')
   .demand(1)
   .version(pkg.version)
@@ -53,7 +59,7 @@ function execute(args) {
         reject(err);
       } else {
         const schema = JSON.parse(res);
-        generate(schema, {assert: args.assert, name: args.name}).then(code => {
+        generate(schema, {assert: args.assert, name: args.name, sep: args.sep}).then(code => {
           if (!args.output) {
             process.stdout.write(code);
             return resolve(code);

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,11 +18,18 @@ const clientTpl = lodashTemplate(
  * @param {string} str - target string
  * @param {Object} [options] - options
  * @param {string} [options.sep] - word separator in URIs (default. -)
+ * @param {string} [style] - ucc or lcc (default. ucc)
  * @return {string}
  */
-function camelize(str, options) {
+function camelize(str, options, style) {
   const opts = options || {sep: '-'};
-  return str.split(opts.sep).map(s => `${s[0].toUpperCase()}${s.slice(1)}`).join('');
+  const s = style || 'ucc';
+  const ucc = str.split(opts.sep).map(s => `${s[0].toUpperCase()}${s.slice(1)}`).join('');
+  if (s === 'ucc') {
+    return ucc;
+  } else if (s === 'lcc') {
+    return ucc.charAt(0).toLowerCase() + ucc.slice(1);
+  }
 }
 
 /**
@@ -149,7 +156,7 @@ function generate(json, options) {
           requestRequired: !!(link.schema && link.schema.required),
           responseFlow: resFlow,
           method: link.method.toLowerCase(),
-          name: `${key}${camelize(link.rel, opts)}`
+          name: `${camelize(key, opts, 'lcc')}${camelize(link.rel, opts)}`
         }).replace(/\n\s*\n/g, '\n');
         methods.push(method);
       });

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,7 @@ const clientTpl = lodashTemplate(
  *
  * @param {string} str - target string
  * @param {Object} [options] - options
- * @param {string} [options.sep] - separator
+ * @param {string} [options.sep] - word separator in URIs (default. -)
  * @return {string}
  */
 function camelize(str, options) {
@@ -76,6 +76,7 @@ function toFlowtype(schema, depth) {
  * @param {Object} [options] - options
  * @param {Object} [options.name] - API Client class name (default. APIClient)
  * @param {Object} [options.assert] - assert library name (default. power-assert)
+ * @param {Object} [options.sep] - word separator in URIs (default. -)
  * @return {Promise<string>}
  */
 function generate(json, options) {
@@ -84,13 +85,14 @@ function generate(json, options) {
   const opts = options || {};
   opts.name = opts.name || 'APIClient';
   opts.assert = opts.assert || 'power-assert';
+  opts.sep = opts.sep || '-';
   return parser.dereference(json).then(schema => {
     const methods = [];
     const linkFlowtypes = [];
     const resourceFlowtypes = [];
     Object.keys(schema.properties).sort().forEach(key => {
       const resource = schema.properties[key];
-      resourceFlowtypes.push(`export type ${camelize(key)} = ${toFlowtype(resource)}`);
+      resourceFlowtypes.push(`export type ${camelize(key, opts)} = ${toFlowtype(resource)}`);
       if (!resource.links) {
         return undefined;
       }
@@ -116,8 +118,8 @@ function generate(json, options) {
           href = href.replace(a.orgKey, a.key);
         });
         let args = hrefArgs;
-        const reqFlow = `${camelize(key)}${camelize(link.rel)}Request`;
-        const resFlow = `${camelize(key)}${camelize(link.rel)}Response`;
+        const reqFlow = `${camelize(key, opts)}${camelize(link.rel, opts)}Request`;
+        const resFlow = `${camelize(key, opts)}${camelize(link.rel, opts)}Response`;
         if (link.schema) {
           args = args.concat([{
             key: 'params',
@@ -147,7 +149,7 @@ function generate(json, options) {
           requestRequired: !!(link.schema && link.schema.required),
           responseFlow: resFlow,
           method: link.method.toLowerCase(),
-          name: `${key}${camelize(link.rel)}`
+          name: `${key}${camelize(link.rel, opts)}`
         }).replace(/\n\s*\n/g, '\n');
         methods.push(method);
       });


### PR DESCRIPTION
Case of underscore used to separate words in the resource id ( e.g. `/agency_report`), generated resources were like `Agency_report`.
So, I want to add the option `sep` for word separator of URIs.
Then, with `--sep=_` option, I'll be able to handle underscore.







